### PR TITLE
Move expo options to app.json

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -1,5 +1,9 @@
 {
-  "expo": {
-    "sdkVersion": "27.0.0"
-  }
+	"expo": {
+		"sdkVersion": "27.0.0",
+		"packagerOpts": {
+			"sourceExts": ["js", "jsx", "scss", "sass"],
+			"transformer": "node_modules/react-native-sass-transformer/index.js"
+		}
+	}
 }

--- a/app/package.json
+++ b/app/package.json
@@ -12,17 +12,6 @@
   "jest": {
     "preset": "jest-expo"
   },
-  "expo": {
-    "packagerOpts": {
-      "sourceExts": [
-        "js",
-        "jsx",
-        "scss",
-        "sass"
-      ],
-      "transformer": "node_modules/react-native-sass-transformer/index.js"
-    }
-  },
   "dependencies": {
     "expo": "^27.0.1",
     "react": "16.3.1",


### PR DESCRIPTION
This fixes the issues with React Native not picking up the `.scss` files.